### PR TITLE
Update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -48,7 +48,7 @@ module.exports = {
 #### - compositor.config.js
 
 ```
-const compositorConfig = {
+module.exports = {
   // root unit
   root: 16,
 


### PR DESCRIPTION
`compositor.config.js` requires a module to be exported rather than a variable defined as it currently states in the readme.